### PR TITLE
FQDN() now gives fqdn, was only hostname before

### DIFF
--- a/format/format.go
+++ b/format/format.go
@@ -21,16 +21,18 @@
 package format
 
 import (
+	"bytes"
 	"encoding/json"
 	"fmt"
 	"github.com/bobziuchkovski/cue"
 	"os"
+	"os/exec"
 	"reflect"
 	"sort"
 	"strconv"
 	"strings"
 	"time"
-	"unicode"
+	"unicode"	
 )
 
 // Color codes for use with Colorize.
@@ -278,11 +280,12 @@ func Hostname(buffer Buffer, event *cue.Event) {
 // FQDN writes the host's fully-qualified domain name (FQDN) to the buffer.
 // If the FQDN cannot be determined, "unknown" is written instead.
 func FQDN(buffer Buffer, event *cue.Event) {
-	name, err := os.Hostname()
-	if err != nil {
-		name = "unknown"
+	out, err := exec.Command("/bin/hostname", "-f").Output()
+	if err == nil {
+		buffer.Append(bytes.TrimSpace(out))
+	} else {
+		buffer.AppendString("unknown")
 	}
-	buffer.AppendString(name)
 }
 
 // Level writes event.Level.String() to the buffer.  Hence, it writes "INFO"


### PR DESCRIPTION
os.Hostname() does not return FQDN (at least not on Linux)